### PR TITLE
added support for chef-manage and other chef plugins.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM ubuntu:14.04
 MAINTAINER Maciej Pasternacki <maciej@3ofcoins.net>
 
-EXPOSE 80 443
+EXPOSE 80 443 10000 10002
 
 # Switched to use entire /var/opt as volume, but keeping all options in the list for reference
 #VOLUME /var/opt/opscode /var/opt /var/opt/chef-backup /var/opt/chef-manage /var/opt/chef-server /var/opt/chef-sync /var/opt/opscode-push-jobs-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,16 @@ FROM ubuntu:14.04
 MAINTAINER Maciej Pasternacki <maciej@3ofcoins.net>
 
 EXPOSE 80 443
-VOLUME /var/opt/opscode
+
+# Switched to use entire /var/opt as volume, but keeping all options in the list for reference
+#VOLUME /var/opt/opscode /var/opt /var/opt/chef-backup /var/opt/chef-manage /var/opt/chef-server /var/opt/chef-sync /var/opt/opscode-push-jobs-server
+VOLUME /var/opt
 
 COPY install.sh /tmp/install.sh
-
 RUN [ "/bin/sh", "/tmp/install.sh" ]
+
+COPY install_plugins.sh /tmp/install_plugins.sh
+RUN [ "/bin/sh", "/tmp/install_plugins.sh" ]
 
 COPY init.rb /init.rb
 COPY chef-server.rb /.chef/chef-server.rb
@@ -19,3 +24,5 @@ COPY backup.sh /usr/local/bin/chef-server-backup
 ENV KNIFE_HOME /etc/chef
 
 CMD [ "/opt/opscode/embedded/bin/ruby", "/init.rb" ]
+
+

--- a/chef-server.rb
+++ b/chef-server.rb
@@ -25,6 +25,7 @@ end
 
 bookshelf['external_url'] = _uri.to_s
 bookshelf['url'] = _uri.to_s
+nginx['enable'] = true
 nginx['enable_non_ssl'] = true
 nginx['url'] = _uri.to_s
 nginx['x_forwarded_proto'] = _uri.scheme

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ cd "$tmpdir"
 # Install prerequisites
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -q --yes
-apt-get install -q --yes logrotate vim-nox hardlink wget ca-certificates
+apt-get install -q --yes logrotate vim-nox hardlink wget ca-certificates apt-transport-https telnet curl nano
 
 # Download and install Chef's packages
 wget -nv https://web-dl.packagecloud.io/chef/stable/packages/ubuntu/trusty/chef-server-core_12.4.1-1_amd64.deb

--- a/install_plugins.sh
+++ b/install_plugins.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set +x
+
+echo "INSTALLING PLUGINS"
+echo "Install Chef Manage"
+{
+    chef-server-ctl install chef-manage
+} || {
+	echo "Sometimes packagecloud exception is raised in apt-get and we need to clear cached apt sources"
+    rm -rf /var/lib/apt/lists/*
+    chef-server-ctl install chef-manage
+}
+chef-manage-ctl reconfigure
+
+echo "Install Reporting"
+chef-server-ctl install opscode-reporting
+opscode-reporting-ctl reconfigure
+
+echo "Install Chef Push"
+chef-server-ctl install opscode-push-jobs-server
+opscode-push-jobs-server-ctl reconfigure
+
+echo "Install Chef Sync"
+chef-server-ctl install chef-sync
+echo "chef-sync-ctl reconfigure"
+
+echo "Plugins installed"


### PR DESCRIPTION
Seems like many people, including myself, struggle with installing chef-server with plugins in docker. 
I made a few changes to install the plugins. Please see my comment at the end re reconfigure / restart

VOLUME declaration seems a little off, i was under the impression that it should be just after all RUN ADD COPY operations and prior to ENTRYPOINT and CMD commands in order to maintain files on volumes, but despite that - everything appears to work fine.

*_TODO: *_ 
need to investigate why sometimes after install - i still need to login to do (and probably for reporting, sync and other commands as well:

```
chef-server-ctl reconfigure 
chef-manager-ctl reconfigure 
chef-server-ctl restart
chef-manager-ctl restart 
```

restart commands for server to come online
