### PR TITLE
Update 12.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # avoid adding .deb during development
 *.deb
+tmp/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Chef Server
 This image runs
 [Chef Server 12](https://downloads.getchef.com/chef-server/). The
 latest version is published as `quay.io/3ofcoins/chef-server:latest`. Version
-tags are available; current one is `quay.io/3ofcoins/chef-server:12.2.0`.
+tags are available; current one is `quay.io/3ofcoins/chef-server:12.6.0`.
 
 Git repository containing the Dockerfile lives at
 https://github.com/3ofcoins/docker-chef-server/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Chef Server
 This image runs
 [Chef Server 12](https://downloads.getchef.com/chef-server/). The
 latest version is published as `quay.io/3ofcoins/chef-server:latest`. Version
-tags are available; current one is `quay.io/3ofcoins/chef-server:12.6.0`.
+tags are available; current one is `quay.io/3ofcoins/chef-server:12.8.0`.
 
 Git repository containing the Dockerfile lives at
 https://github.com/3ofcoins/docker-chef-server/

--- a/backup.sh
+++ b/backup.sh
@@ -17,7 +17,7 @@ done
 
 mkdir organizations
 for org in $(chef-server-ctl org-list) ; do
-    chef-server-ctl org-show -l -F json $org > organizations/$org.json
+    chef-server-ctl org-show -F json $org > organizations/$org.json
     mkdir organizations/$org
     env CHEF_ORGANIZATION=$org knife download --chef-repo-path=organizations/$org /
 done

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 set -e -x
 
-SERVER_VERSION="12.6.0"
-SERVER_SHA1="eafc7aedd4966457cd77eb51f75da863947dde70"
-CLIENT_VERSION="12.10.24"
-CLIENT_SHA1="7d30b300f95f00036919ee8bf3b95ab73429e57e"
+SERVER_VERSION="12.8.0"
+SERVER_SHA1="4111123ba0c869e26a069f6d4625ad193e27ec99"
+CLIENT_VERSION="12.12.13"
+CLIENT_SHA1="e4db4a79ea6d8dac04829a13b489df77085a067e"
 
 # Temporary work dir
 tmpdir="`mktemp -d`"
@@ -16,8 +16,8 @@ apt-get update -q --yes
 apt-get install -q --yes logrotate vim-nox hardlink wget ca-certificates
 
 # Download and install Chef's packages
-wget -nv https://packages.chef.io/stable/ubuntu/14.04/chef-server-core_${SERVER_VERSION}-1_amd64.deb
-wget -nv https://packages.chef.io/stable/ubuntu/10.04/chef_${CLIENT_VERSION}-1_amd64.deb
+wget -nv --no-check-certificate https://packages.chef.io/stable/ubuntu/14.04/chef-server-core_${SERVER_VERSION}-1_amd64.deb
+wget -nv --no-check-certificate https://packages.chef.io/stable/ubuntu/14.04/chef_${CLIENT_VERSION}-1_amd64.deb
 
 sha1sum -c - <<EOF
 ${SERVER_SHA1}  chef-server-core_${SERVER_VERSION}-1_amd64.deb

--- a/install.sh
+++ b/install.sh
@@ -11,12 +11,12 @@ apt-get update -q --yes
 apt-get install -q --yes logrotate vim-nox hardlink wget ca-certificates
 
 # Download and install Chef's packages
-wget -nv https://web-dl.packagecloud.io/chef/stable/packages/ubuntu/trusty/chef-server-core_12.4.1-1_amd64.deb
-wget -nv https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/10.04/x86_64/chef_12.7.2-1_amd64.deb
+wget -nv https://packages.chef.io/stable/ubuntu/14.04/chef-server-core_12.6.0-1_amd64.deb
+wget -nv https://packages.chef.io/stable/ubuntu/10.04/chef_12.10.24-1_amd64.deb
 
 sha1sum -c - <<EOF
-a75e8dbcce749adf61a60ca0ccf25fc041e4774a  chef-server-core_12.4.1-1_amd64.deb
-9bc701d90ba12c71fbe51a8bdcdf25e864375f4e  chef_12.7.2-1_amd64.deb
+eafc7aedd4966457cd77eb51f75da863947dde70  chef-server-core_12.6.0-1_amd64.deb
+7d30b300f95f00036919ee8bf3b95ab73429e57e  chef_12.10.24-1_amd64.deb
 EOF
 
 dpkg -i chef-server-core_12.4.1-1_amd64.deb chef_12.7.2-1_amd64.deb

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e -x
 
+SERVER_VERSION="12.6.0"
+SERVER_SHA1="eafc7aedd4966457cd77eb51f75da863947dde70"
+CLIENT_VERSION="12.10.24"
+CLIENT_SHA1="7d30b300f95f00036919ee8bf3b95ab73429e57e"
+
 # Temporary work dir
 tmpdir="`mktemp -d`"
 cd "$tmpdir"
@@ -11,15 +16,15 @@ apt-get update -q --yes
 apt-get install -q --yes logrotate vim-nox hardlink wget ca-certificates
 
 # Download and install Chef's packages
-wget -nv https://packages.chef.io/stable/ubuntu/14.04/chef-server-core_12.6.0-1_amd64.deb
-wget -nv https://packages.chef.io/stable/ubuntu/10.04/chef_12.10.24-1_amd64.deb
+wget -nv https://packages.chef.io/stable/ubuntu/14.04/chef-server-core_${SERVER_VERSION}-1_amd64.deb
+wget -nv https://packages.chef.io/stable/ubuntu/10.04/chef_${CLIENT_VERSION}-1_amd64.deb
 
 sha1sum -c - <<EOF
-eafc7aedd4966457cd77eb51f75da863947dde70  chef-server-core_12.6.0-1_amd64.deb
-7d30b300f95f00036919ee8bf3b95ab73429e57e  chef_12.10.24-1_amd64.deb
+${SERVER_SHA1}  chef-server-core_${SERVER_VERSION}-1_amd64.deb
+${CLIENT_SHA1}  chef_${CLIENT_VERSION}-1_amd64.deb
 EOF
 
-dpkg -i chef-server-core_12.4.1-1_amd64.deb chef_12.7.2-1_amd64.deb
+dpkg -i chef-server-core_${SERVER_VERSION}-1_amd64.deb chef_${CLIENT_VERSION}-1_amd64.deb
 
 # Extra setup
 rm -rf /etc/opscode


### PR DESCRIPTION
Update to Chef Server 12.8.0 and latest chef client 12.12.13. This pull request also has the changes from @derks in it which means it deprecates #5.
