### PR TITLE
Ubuntu16 / Chef Update And Orchestration Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # avoid adding .deb during development
 *.deb
+tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # -*- conf -*-
 
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 MAINTAINER Maciej Pasternacki <maciej@3ofcoins.net>
 
 EXPOSE 80 443

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Chef Server
 This image runs
 [Chef Server 12](https://downloads.getchef.com/chef-server/). The
 latest version is published as `quay.io/3ofcoins/chef-server:latest`. Version
-tags are available; current one is `quay.io/3ofcoins/chef-server:12.2.0`.
+tags are available; current one is `quay.io/3ofcoins/chef-server:12.8.0`.
 
 Git repository containing the Dockerfile lives at
 https://github.com/3ofcoins/docker-chef-server/

--- a/backup.sh
+++ b/backup.sh
@@ -17,7 +17,7 @@ done
 
 mkdir organizations
 for org in $(chef-server-ctl org-list) ; do
-    chef-server-ctl org-show -l -F json $org > organizations/$org.json
+    chef-server-ctl org-show -F json $org > organizations/$org.json
     mkdir organizations/$org
     env CHEF_ORGANIZATION=$org knife download --chef-repo-path=organizations/$org /
 done

--- a/init.rb
+++ b/init.rb
@@ -90,6 +90,12 @@ log 'Preparing configuration ...'
 FileUtils.mkdir_p %w'/var/opt/opscode/log /var/opt/opscode/etc /.chef/env', verbose: true
 FileUtils.cp '/.chef/chef-server.rb', '/var/opt/opscode/etc', verbose: true
 
+begin
+  hostn = File.read("/var/opt/opscode/hostname").chomp
+rescue
+  hostn = ""
+end
+
 %w'PUBLIC_URL OC_ID_ADMINISTRATORS'.each do |var|
   File.write(File.join('/.chef/env', var), ENV[var].to_s)
 end
@@ -119,6 +125,11 @@ Signal.trap 'USR1' do
   log 'Chef Server status:'
   run! '/usr/bin/chef-server-ctl', 'status'
 end
+
+unless hostn.eql? `hostname`.strip
+  reconfigure! 'New container'
+end
+File.write('/var/opt/opscode/hostname',`hostname`.strip)
 
 unless File.exist? '/var/opt/opscode/bootstrapped'
   reconfigure! 'Not bootstrapped'

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e -x
 
+SERVER_VERSION="12.10.0"
+SERVER_SHA1="95fce9f167972418b3f06b9e5fe95f8a3f0e5361"
+CLIENT_VERSION="12.16.42"
+CLIENT_SHA1="e720803538b5db3cc9924121e3aa9e5a7a03cf79"
+
 # Temporary work dir
 tmpdir="`mktemp -d`"
 cd "$tmpdir"
@@ -8,18 +13,19 @@ cd "$tmpdir"
 # Install prerequisites
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -q --yes
-apt-get install -q --yes logrotate vim-nox hardlink wget ca-certificates
+apt-get install -q --yes logrotate vim-nox hardlink wget ca-certificates upstart-sysv # chefserver is not yet compatible with systemd
+update-initramfs -u
 
 # Download and install Chef's packages
-wget -nv https://web-dl.packagecloud.io/chef/stable/packages/ubuntu/trusty/chef-server-core_12.4.1-1_amd64.deb
-wget -nv https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/10.04/x86_64/chef_12.7.2-1_amd64.deb
+wget -nv https://packages.chef.io/stable/ubuntu/16.04/chef-server-core_${SERVER_VERSION}-1_amd64.deb
+wget -nv https://packages.chef.io/stable/ubuntu/16.04/chef_${CLIENT_VERSION}-1_amd64.deb
 
 sha1sum -c - <<EOF
-a75e8dbcce749adf61a60ca0ccf25fc041e4774a  chef-server-core_12.4.1-1_amd64.deb
-9bc701d90ba12c71fbe51a8bdcdf25e864375f4e  chef_12.7.2-1_amd64.deb
+${SERVER_SHA1}  chef-server-core_${SERVER_VERSION}-1_amd64.deb
+${CLIENT_SHA1}  chef_${CLIENT_VERSION}-1_amd64.deb
 EOF
 
-dpkg -i chef-server-core_12.4.1-1_amd64.deb chef_12.7.2-1_amd64.deb
+dpkg -i chef-server-core_${SERVER_VERSION}-1_amd64.deb chef_${CLIENT_VERSION}-1_amd64.deb
 
 # Extra setup
 rm -rf /etc/opscode


### PR DESCRIPTION
- Update to Ubuntu 16.04
- Update to ChefServer 12.10
- Update to ChefClient 12.16.42
- Allow Container Orchestration (kubernetes, swarn ...) : on container migration, or rebuil reconfigure is forced